### PR TITLE
Fix #19

### DIFF
--- a/flutter_native_log_handler/ios/Classes/SwiftFlutterNativeLogsPlugin.swift
+++ b/flutter_native_log_handler/ios/Classes/SwiftFlutterNativeLogsPlugin.swift
@@ -65,9 +65,6 @@ class MyStreamHandler: NSObject, FlutterStreamHandler {
     public func addMessage(message: String) {
         DispatchQueue.main.async {
             self.eventSink?(message)
-            if(self.eventSink != nil) {
-                self.eventSink!(message)
-            }
         }
     }
 }

--- a/flutter_native_log_handler/ios/Classes/SwiftFlutterNativeLogsPlugin.swift
+++ b/flutter_native_log_handler/ios/Classes/SwiftFlutterNativeLogsPlugin.swift
@@ -52,8 +52,6 @@ class MyStreamHandler: NSObject, FlutterStreamHandler {
 
     public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
         eventSink = events
-        events("Test")
-        eventSink?("Test2")
         return nil
     }
 

--- a/flutter_native_log_handler/ios/Classes/SwiftFlutterNativeLogsPlugin.swift
+++ b/flutter_native_log_handler/ios/Classes/SwiftFlutterNativeLogsPlugin.swift
@@ -11,7 +11,6 @@ public class SwiftFlutterNativeLogsPlugin: NSObject, FlutterPlugin {
         eventChannel.setStreamHandler(myStreamHandler)
 
         let pipe = Pipe()
-        // dup2(STDOUT_FILENO, pipe.fileHandleForWriting.fileDescriptor)
         setvbuf(stdout, nil, _IONBF, 0)
         setvbuf(stderr, nil, _IONBF, 0)
         dup2(pipe.fileHandleForWriting.fileDescriptor, FileHandle.standardOutput.fileDescriptor)
@@ -31,15 +30,6 @@ public class SwiftFlutterNativeLogsPlugin: NSObject, FlutterPlugin {
 
             pipe.fileHandleForReading.waitForDataInBackgroundAndNotify()
         }
-
-        /* pipe.fileHandleForReading.readabilityHandler = { fileHandle in
-            let data = fileHandle.availableData
-            if let string = String(data: data, encoding: String.Encoding.utf8) {
-                DispatchQueue.main.async {
-                    myStreamHandler.addMessage(message: string)
-                }
-            }
-        } */
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/flutter_native_log_handler/ios/Classes/SwiftFlutterNativeLogsPlugin.swift
+++ b/flutter_native_log_handler/ios/Classes/SwiftFlutterNativeLogsPlugin.swift
@@ -10,25 +10,37 @@ public class SwiftFlutterNativeLogsPlugin: NSObject, FlutterPlugin {
         let eventChannel = FlutterEventChannel(name: "flutter_native_log_handler/logs", binaryMessenger: registrar.messenger())
         eventChannel.setStreamHandler(myStreamHandler)
 
-        let pipe = Pipe()
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+
+        // dup2(STDOUT_FILENO, pipe.fileHandleForWriting.fileDescriptor)
         setvbuf(stdout, nil, _IONBF, 0)
         setvbuf(stderr, nil, _IONBF, 0)
-        dup2(pipe.fileHandleForWriting.fileDescriptor, FileHandle.standardOutput.fileDescriptor)
-        dup2(pipe.fileHandleForWriting.fileDescriptor, FileHandle.standardError.fileDescriptor)
 
-        pipe.fileHandleForReading.waitForDataInBackgroundAndNotify()
+        // Copy STDOUT file descriptor to outputPipe for writing strings back to STDOUT
+        dup2(FileHandle.standardOutput.fileDescriptor, outputPipe.fileHandleForWriting.fileDescriptor)
+        dup2(FileHandle.standardError.fileDescriptor, outputPipe.fileHandleForWriting.fileDescriptor)
 
-        NotificationCenter.default.addObserver(forName: NSNotification.Name.NSFileHandleDataAvailable, object: pipe.fileHandleForReading , queue: nil) {
+        // Intercept STDOUT with inputPipe
+        dup2(inputPipe.fileHandleForWriting.fileDescriptor, FileHandle.standardOutput.fileDescriptor)
+        dup2(inputPipe.fileHandleForWriting.fileDescriptor, FileHandle.standardError.fileDescriptor)
+
+        inputPipe.fileHandleForReading.waitForDataInBackgroundAndNotify()
+
+        NotificationCenter.default.addObserver(forName: NSNotification.Name.NSFileHandleDataAvailable, object: inputPipe.fileHandleForReading , queue: nil) {
             notification in
 
-            let output = pipe.fileHandleForReading.availableData
+            let output = inputPipe.fileHandleForReading.availableData
             let outputString = String(data: output, encoding: String.Encoding.utf8) ?? ""
 
             DispatchQueue.main.async {
                 myStreamHandler.addMessage(message: outputString)
             }
 
-            pipe.fileHandleForReading.waitForDataInBackgroundAndNotify()
+            // Write input back to stdout
+            outputPipe.fileHandleForWriting.write(output)
+
+            inputPipe.fileHandleForReading.waitForDataInBackgroundAndNotify()
         }
     }
 


### PR DESCRIPTION
Some IDEs don't work anymore if there is no console log. (VSCode, XCode)

Changed the plugin so that the stdout and stderr are duplicated, once going into a file but still appearing on the console.

Other changes:
- Removed some debug logs.
- Removed duplicate logging.
- Removed some commented out code.