### PR TITLE
Handle IOException

### DIFF
--- a/flutter_native_log_handler/android/src/main/kotlin/de/goddchen/flutter/flutter_native_logs/FlutterNativeLogsPlugin.kt
+++ b/flutter_native_log_handler/android/src/main/kotlin/de/goddchen/flutter/flutter_native_logs/FlutterNativeLogsPlugin.kt
@@ -9,6 +9,7 @@ import io.flutter.plugin.common.EventChannel.StreamHandler
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import java.io.IOException
 import kotlin.concurrent.thread
 
 /** FlutterNativeLogsPlugin */
@@ -33,14 +34,18 @@ class FlutterNativeLogsPlugin : FlutterPlugin, MethodCallHandler, StreamHandler 
             Runtime.getRuntime().exec("logcat -c")
             logcatProcess = Runtime.getRuntime().exec("logcat")
             logcatProcess?.let {
-                it
-                    .inputStream
-                    .bufferedReader()
-                    .useLines { lines ->
-                        lines.forEach { line ->
-                            Handler(Looper.getMainLooper()).post { eventSink?.success(line) }
+                try {
+                    it
+                        .inputStream
+                        .bufferedReader()
+                        .useLines { lines ->
+                            lines.forEach { line ->
+                                Handler(Looper.getMainLooper()).post { eventSink?.success(line) }
+                            }
                         }
-                    }
+                } catch (e: IOException) {
+                    // Don't send logs to the channel
+                }
             }
         }
         // thread(start = true) {


### PR DESCRIPTION
While the plugin was closing, the `lines.forEach` method was executed, and caused an error in the iterator 

#24 